### PR TITLE
Add Avro message deserialization capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,33 +94,3 @@ Starting in version 2.0.0, Kafdrop sets CORS headers for all endpoints. You can 
 You can also disable CORS entirely with the following configuration:
 
     cors.enabled=false
-
-## Avro Consumer
-
-References:
-* http://cloudurable.com/blog/kafka-avro-schema-registry/index.html
-* https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html
-* https://github.com/confluentinc/schema-registry/blob/master/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
-* https://docs.confluent.io/3.0.0/installation.html#maven-repository-for-jars
-
-Java Docs:
-* https://www.javadoc.io/doc/org.apache.kafka/kafka_2.9.2/0.8.0
-* https://www.javadoc.io/doc/org.apache.kafka/kafka-clients/0.8.2.2
-* https://www.javadoc.io/doc/org.apache.kafka/kafka-clients/0.10.2.0
-* https://www.javadoc.io/doc/org.apache.kafka/kafka-clients/0.10.2.2
-
-Sources:
-* https://github.com/apache/kafka/tree/0.8.2/core/src/main/scala/kafka/javaapi
-
-## Development
-
-Project setup for Eclipse:
-```
-mvn dependency:tree
-mvn eclipse:clean
-mvn eclipse:eclipse
-```
-
-For run configurations, add a new Maven run configuration called 'Default Build'
-with the project workspace as the root, and then add `clean package` as the goals
-and hit apply.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Then open a browser and navigate to http://localhost:9000. The port can be overr
     --server.port=<port>
 ```
 
+Additionally, you can configure a schema registry connection with:
+```
+    --schemaregistry.connect=http://localhost:8081
+```
+
 ## Running with Docker
 
 Note for Mac Users: You need to convert newline formatting of the kafdrop.sh file *before* running this command:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Kafdrop is a UI for monitoring Apache Kafka clusters. The tool displays informat
 * Kafka (0.8.1 or 0.8.2 is known to work)
 * Zookeeper (3.4.5 or later)
 
+Optional, additional integration:
+
+* Schema Registry
+
 ## Building
 
 After cloning the repository, building should just be a matter of running a standard Maven build:

--- a/README.md
+++ b/README.md
@@ -89,3 +89,33 @@ Starting in version 2.0.0, Kafdrop sets CORS headers for all endpoints. You can 
 You can also disable CORS entirely with the following configuration:
 
     cors.enabled=false
+
+## Avro Consumer
+
+References:
+* http://cloudurable.com/blog/kafka-avro-schema-registry/index.html
+* https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html
+* https://github.com/confluentinc/schema-registry/blob/master/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+* https://docs.confluent.io/3.0.0/installation.html#maven-repository-for-jars
+
+Java Docs:
+* https://www.javadoc.io/doc/org.apache.kafka/kafka_2.9.2/0.8.0
+* https://www.javadoc.io/doc/org.apache.kafka/kafka-clients/0.8.2.2
+* https://www.javadoc.io/doc/org.apache.kafka/kafka-clients/0.10.2.0
+* https://www.javadoc.io/doc/org.apache.kafka/kafka-clients/0.10.2.2
+
+Sources:
+* https://github.com/apache/kafka/tree/0.8.2/core/src/main/scala/kafka/javaapi
+
+## Development
+
+Project setup for Eclipse:
+```
+mvn dependency:tree
+mvn eclipse:clean
+mvn eclipse:eclipse
+```
+
+For run configurations, add a new Maven run configuration called 'Default Build'
+with the project workspace as the root, and then add `clean package` as the goals
+and hit apply.

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
          <artifactId>jsr305</artifactId>
          <version>3.0.2</version>
       </dependency>
+      <dependency>
+         <groupId>com.google.code.gson</groupId>
+         <artifactId>gson</artifactId>
+         <version>2.8.5</version>
+      </dependency>
 
       <!-- Spring Boot -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
          <artifactId>kafka-clients</artifactId>
          <version>0.10.2.2</version>
       </dependency>
+      <dependency>
+         <groupId>com.google.code.findbugs</groupId>
+         <artifactId>jsr305</artifactId>
+         <version>3.0.2</version>
+      </dependency>
 
       <!-- Spring Boot -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,17 @@
        <tag>HEAD</tag>
    </scm>
 
+   <repositories>
+     <repository>
+       <id>central</id>
+       <url>http://repo1.maven.org/maven2</url>
+     </repository>
+     <repository>
+       <id>confluent</id>
+       <url>http://packages.confluent.io/maven/</url>
+     </repository>
+   </repositories>
+
    <dependencyManagement>
       <dependencies>
          <dependency>
@@ -72,6 +83,21 @@
          <groupId>org.springframework.retry</groupId>
          <artifactId>spring-retry</artifactId>
          <version>1.1.3.RELEASE</version>
+      </dependency>
+      <dependency>
+         <groupId>io.confluent</groupId>
+         <artifactId>kafka-avro-serializer</artifactId>
+         <version>3.2.1</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.avro</groupId>
+         <artifactId>avro</artifactId>
+         <version>1.8.1</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.kafka</groupId>
+         <artifactId>kafka-clients</artifactId>
+         <version>0.10.2.2</version>
       </dependency>
 
       <!-- Spring Boot -->
@@ -150,13 +176,6 @@
          <groupId>org.codehaus.groovy.modules.http-builder</groupId>
          <artifactId>http-builder</artifactId>
          <version>0.7.1</version>
-         <scope>test</scope>
-      </dependency>
-      <!-- Right now only needed by integration tests -->
-      <dependency>
-         <groupId>org.apache.kafka</groupId>
-         <artifactId>kafka-clients</artifactId>
-         <version>0.8.2.2</version>
          <scope>test</scope>
       </dependency>
    </dependencies>
@@ -313,7 +332,7 @@
                      <dependency>
                         <groupId>org.apache.kafka</groupId>
                         <artifactId>kafka-clients</artifactId>
-                        <version>0.8.2.2</version>
+                        <version>0.10.2.2</version>
                      </dependency>
                   </dependencies>
 

--- a/src/main/java/com/homeadvisor/kafdrop/config/SchemaRegistryConfiguration.java
+++ b/src/main/java/com/homeadvisor/kafdrop/config/SchemaRegistryConfiguration.java
@@ -1,0 +1,44 @@
+package com.homeadvisor.kafdrop.config;
+
+import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Configuration
+public class SchemaRegistryConfiguration {
+
+
+    @Component
+    @ConfigurationProperties(prefix = "schemaregistry")
+    public static class SchemaRegistryProperties
+    {
+        public static final Pattern CONNECT_SEPARATOR = Pattern.compile("\\s*,\\s*");
+        @NotBlank
+        private String connect;
+
+        public String getConnect()
+        {
+            return connect;
+        }
+
+        public void setConnect(String connect)
+        {
+            this.connect = connect;
+        }
+
+        public List<String> getConnectList()
+        {
+            return CONNECT_SEPARATOR.splitAsStream(this.connect)
+                    .map(String::trim)
+                    .filter(s -> s.length() > 0)
+                    .collect(Collectors.toList());
+        }
+
+    }
+
+}

--- a/src/main/java/com/homeadvisor/kafdrop/config/SchemaRegistryConfiguration.java
+++ b/src/main/java/com/homeadvisor/kafdrop/config/SchemaRegistryConfiguration.java
@@ -5,9 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Configuration
 public class SchemaRegistryConfiguration {
@@ -17,7 +14,6 @@ public class SchemaRegistryConfiguration {
     @ConfigurationProperties(prefix = "schemaregistry")
     public static class SchemaRegistryProperties
     {
-        public static final Pattern CONNECT_SEPARATOR = Pattern.compile("\\s*,\\s*");
         @NotBlank
         private String connect;
 
@@ -29,14 +25,6 @@ public class SchemaRegistryConfiguration {
         public void setConnect(String connect)
         {
             this.connect = connect;
-        }
-
-        public List<String> getConnectList()
-        {
-            return CONNECT_SEPARATOR.splitAsStream(this.connect)
-                    .map(String::trim)
-                    .filter(s -> s.length() > 0)
-                    .collect(Collectors.toList());
         }
 
     }

--- a/src/main/java/com/homeadvisor/kafdrop/config/SchemaRegistryConfiguration.java
+++ b/src/main/java/com/homeadvisor/kafdrop/config/SchemaRegistryConfiguration.java
@@ -1,6 +1,5 @@
 package com.homeadvisor.kafdrop.config;
 
-import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
@@ -9,12 +8,10 @@ import org.springframework.stereotype.Component;
 @Configuration
 public class SchemaRegistryConfiguration {
 
-
     @Component
     @ConfigurationProperties(prefix = "schemaregistry")
     public static class SchemaRegistryProperties
     {
-        @NotBlank
         private String connect;
 
         public String getConnect()

--- a/src/main/java/com/homeadvisor/kafdrop/config/SchemaRegistryConfiguration.java
+++ b/src/main/java/com/homeadvisor/kafdrop/config/SchemaRegistryConfiguration.java
@@ -4,6 +4,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Configuration
 public class SchemaRegistryConfiguration {
@@ -12,6 +15,9 @@ public class SchemaRegistryConfiguration {
     @ConfigurationProperties(prefix = "schemaregistry")
     public static class SchemaRegistryProperties
     {
+
+        public static final Pattern CONNECT_SEPARATOR = Pattern.compile("\\s*,\\s*");
+
         private String connect;
 
         public String getConnect()
@@ -22,6 +28,14 @@ public class SchemaRegistryConfiguration {
         public void setConnect(String connect)
         {
             this.connect = connect;
+        }
+
+        public List<String> getConnectList()
+        {
+            return CONNECT_SEPARATOR.splitAsStream(this.connect)
+                    .map(String::trim)
+                    .filter(s -> s.length() > 0)
+                    .collect(Collectors.toList());
         }
 
     }

--- a/src/main/java/com/homeadvisor/kafdrop/controller/MessageController.java
+++ b/src/main/java/com/homeadvisor/kafdrop/controller/MessageController.java
@@ -20,6 +20,7 @@ package com.homeadvisor.kafdrop.controller;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.homeadvisor.kafdrop.config.SchemaRegistryConfiguration;
 import com.homeadvisor.kafdrop.model.MessageVO;
 import com.homeadvisor.kafdrop.model.TopicVO;
 import com.homeadvisor.kafdrop.service.KafkaMonitor;
@@ -51,6 +52,9 @@ public class MessageController
    @Autowired
    private MessageInspector messageInspector;
 
+   @Autowired
+   private SchemaRegistryConfiguration.SchemaRegistryProperties schemaRegistryProperties;
+
    /**
     * Human friendly view of reading messages.
     * @param topicName Name of topic
@@ -81,13 +85,16 @@ public class MessageController
          .orElseThrow(() -> new TopicNotFoundException(topicName));
       model.addAttribute("topic", topic);
 
+      final String schemaRegistryUrl = schemaRegistryProperties.getConnect();
+
       if (!messageForm.isEmpty() && !errors.hasErrors())
       {
          model.addAttribute("messages",
                             messageInspector.getMessages(topicName,
                                                          messageForm.getPartition(),
                                                          messageForm.getOffset(),
-                                                         messageForm.getCount()));
+                                                         messageForm.getCount(),
+                                                         schemaRegistryUrl));
       }
 
       return "message-inspector";
@@ -125,12 +132,15 @@ public class MessageController
       }
       else
       {
+         final String schemaRegistryUrl = schemaRegistryProperties.getConnect();
+
          List<Object> messages = new ArrayList<>();
          List<MessageVO> vos = messageInspector.getMessages(
                topicName,
                partition,
                offset,
-               count);
+               count,
+               schemaRegistryUrl);
 
          if(vos != null)
          {

--- a/src/main/java/com/homeadvisor/kafdrop/controller/MessageController.java
+++ b/src/main/java/com/homeadvisor/kafdrop/controller/MessageController.java
@@ -73,7 +73,6 @@ public class MessageController
       {
          final PartitionOffsetInfo defaultForm = new PartitionOffsetInfo();
 
-         // Set Reasonable Defaults. Ideally last 10 messages.
          defaultForm.setCount(10l);
          defaultForm.setOffset(0l);
          defaultForm.setPartition(0);

--- a/src/main/java/com/homeadvisor/kafdrop/controller/MessageController.java
+++ b/src/main/java/com/homeadvisor/kafdrop/controller/MessageController.java
@@ -68,7 +68,12 @@ public class MessageController
       if (messageForm.isEmpty())
       {
          final PartitionOffsetInfo defaultForm = new PartitionOffsetInfo();
-         defaultForm.setCount(1l);
+
+         // Set Reasonable Defaults. Ideally last 10 messages.
+         defaultForm.setCount(10l);
+         defaultForm.setOffset(0l);
+         defaultForm.setPartition(0);
+
          model.addAttribute("messageForm", defaultForm);
       }
 

--- a/src/main/resources/templates/message-inspector.ftl
+++ b/src/main/resources/templates/message-inspector.ftl
@@ -91,7 +91,7 @@
         </div>
     </#list>
     <#elseif !(spring.status.error) && !(messageForm.empty)>
-        No messages found in partition ${messageForm.partition} at offset ${messageForm.offset}
+        No messages found in partition ${(messageForm.partition)!"PARTITION_NOT_SET"} at offset ${messageForm.offset}
     </#if>
 </div>
 


### PR DESCRIPTION
Remaining todos:
- [x]  Parameterize Schema Registry URL.
- [x]  Use something more robust than `.replaceAll()` for JSON rendering.
- [x]  Parameterize ability to deserialize using Avro schemas (e.g. for topics that do not use schemas).
- [x]  Set default to 10 messages in the message viewer.